### PR TITLE
feat(cli): `taskcluster` cli installable via brew

### DIFF
--- a/Formula/taskcluster.rb
+++ b/Formula/taskcluster.rb
@@ -4,19 +4,28 @@ class Taskcluster < Formula
   version "v44.17.2"
   license "MPL-2.0"
 
-  if Hardware::CPU.physical_cpu_arm64?
-    url "https://github.com/taskcluster/taskcluster/releases/download/#{version}/taskcluster-darwin-arm64", :using => :curl
-    sha256 "1ccf56972988f45c88e9a21a536728f1064eabef49a9d085e16ac41db14214a5"
-  else
-    url "https://github.com/taskcluster/taskcluster/releases/download/#{version}/taskcluster-darwin-amd64", :using => :curl
-    sha256 "7897baf6c27350e5a6fe46e93f9bb4890f5dd98a117196acfb4267e639624a5c"
+  if OS.mac?
+    if Hardware::CPU.physical_cpu_arm64?
+      url "https://github.com/taskcluster/taskcluster/releases/download/#{version}/taskcluster-darwin-arm64", :using => :curl
+      sha256 "1ccf56972988f45c88e9a21a536728f1064eabef49a9d085e16ac41db14214a5"
+    else
+      url "https://github.com/taskcluster/taskcluster/releases/download/#{version}/taskcluster-darwin-amd64", :using => :curl
+      sha256 "7897baf6c27350e5a6fe46e93f9bb4890f5dd98a117196acfb4267e639624a5c"
+    end
+  elsif OS.linux?
+    url "https://github.com/taskcluster/taskcluster/releases/download/#{version}/taskcluster-linux-amd64", :using => :curl
+    sha256 "d12b40c048e96bd5376f9d28c4831075ee6b74b3c8b9bd3d85f57cc1a9ec1971"
   end
 
   def install
-    if Hardware::CPU.physical_cpu_arm64?
-      bin.install "taskcluster-darwin-arm64" => "taskcluster"
-    else
-      bin.install "taskcluster-darwin-amd64" => "taskcluster"
+    if OS.mac?
+      if Hardware::CPU.physical_cpu_arm64?
+        bin.install "taskcluster-darwin-arm64" => "taskcluster"
+      else
+        bin.install "taskcluster-darwin-amd64" => "taskcluster"
+      end
+    elsif OS.linux?
+      bin.install "taskcluster-linux-amd64" => "taskcluster"
     end
   end
 

--- a/Formula/taskcluster.rb
+++ b/Formula/taskcluster.rb
@@ -1,0 +1,26 @@
+class Taskcluster < Formula
+  desc "CI for Engineers"
+  homepage "https://taskcluster.net"
+  version "v44.17.2"
+  license "MPL-2.0"
+
+  if Hardware::CPU.physical_cpu_arm64?
+    url "https://github.com/taskcluster/taskcluster/releases/download/#{version}/taskcluster-darwin-arm64", :using => :curl
+    sha256 "1ccf56972988f45c88e9a21a536728f1064eabef49a9d085e16ac41db14214a5"
+  else
+    url "https://github.com/taskcluster/taskcluster/releases/download/#{version}/taskcluster-darwin-amd64", :using => :curl
+    sha256 "7897baf6c27350e5a6fe46e93f9bb4890f5dd98a117196acfb4267e639624a5c"
+  end
+
+  def install
+    if Hardware::CPU.physical_cpu_arm64?
+      bin.install "taskcluster-darwin-arm64" => "taskcluster"
+    else
+      bin.install "taskcluster-darwin-amd64" => "taskcluster"
+    end
+  end
+
+  test do
+    system "#{bin}/taskcluster --help"
+  end
+end


### PR DESCRIPTION
This PR makes the [`taskcluster` cli](https://github.com/taskcluster/taskcluster/tree/main/clients/client-shell) installable via `brew` on both Mac and Linux.

#### To install:
```bash
brew install ./Formula/taskcluster.rb
```
#### To verify installation:
```bash
# now verify it was installed in homebrew's binaries location
which taskcluster
# should output /opt/homebrew/bin/taskcluster

# now try running it!
taskcluster --help
```

Once this PR is merged, the cli will be installable using the following command:
```bash
brew install taskcluster/tap/taskcluster
```

Future work following this PR will be to auto-update this `taskcluster.rb` formula file with the latest version tag and sha256 values for the new binaries.